### PR TITLE
Only use Hybris when available

### DIFF
--- a/src/ubuntu/CMakeLists.txt
+++ b/src/ubuntu/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(application)
-add_subdirectory(hardware)
+if(Hybris)
+  add_subdirectory(hardware)
+endif()

--- a/src/ubuntu/application/CMakeLists.txt
+++ b/src/ubuntu/application/CMakeLists.txt
@@ -14,7 +14,9 @@ include_directories(../../bridge)
 
 add_subdirectory(common)
 add_subdirectory(desktop)
-add_subdirectory(touch)
+if(Hybris)
+  add_subdirectory(touch)
+endif()
 add_subdirectory(testbackend)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11 -fPIC")


### PR DESCRIPTION
Please check if the hybris files are still getting built with this change, it was more or less blindly applied from the Unity8-Arch repo